### PR TITLE
Add mermaid support for canvas tool

### DIFF
--- a/app/hooks/useCanvasTool.ts
+++ b/app/hooks/useCanvasTool.ts
@@ -18,21 +18,34 @@ export default function useCanvasTool() {
             tool({
                 name: "canvas",
                 description: canvasToolInstructions,
-                parameters: z.object({elements: z.string()}),
-                execute: async ({elements}) => {
-                    console.log("Drawing elements", elements);
+                parameters: z.object({
+                    elements: z.string().optional(),
+                    mermaid: z.string().optional(),
+                }).refine((args) => args.elements || args.mermaid, {
+                    message: "elements or mermaid required",
+                }),
+                execute: async ({ elements, mermaid }) => {
+                    console.log("Drawing elements", elements ?? mermaid);
                     if (!excalidraw?.api) {
                         console.log("The canvas was not correctly initialized.");
                         throw new Error("Canvas was not correctly initialized.");
                     }
                     const { convertToExcalidrawElements } = await import("@excalidraw/excalidraw");
-                    const converted = convertToExcalidrawElements(
-                      JSON.parse(elements),
-                    );
-                    excalidraw.api.updateScene({elements: converted});
+
+                    let skeleton;
+                    if (elements) {
+                        skeleton = JSON.parse(elements);
+                    } else {
+                        const { parseMermaidToExcalidraw } = await import("@excalidraw/mermaid-to-excalidraw");
+                        const result = await parseMermaidToExcalidraw(mermaid!);
+                        skeleton = result.elements;
+                    }
+
+                    const converted = convertToExcalidrawElements(skeleton);
+                    excalidraw.api.updateScene({ elements: converted });
                     return "ok";
                 },
             }),
-        [excalidraw],           // recreated whenever the api reference changes
+        [excalidraw], // recreated whenever the api reference changes
     );
 }

--- a/app/lib/prompts.ts
+++ b/app/lib/prompts.ts
@@ -15,14 +15,15 @@ Guidelines
 `;
 
 export const canvasToolInstructions = `
-Draw on the Excalidraw canvas.  Pass a single argument \`elements\`,
-which must be a JSON-encoded string that represents an **array of
-Excalidraw element objects** (same format produced by Excalidraw’s export
-feature). This element list will be converted used \`convertToExcalidrawElements\`.
-The current scene will be completely replaced with these elements.
+Draw on the Excalidraw canvas. Pass either \`elements\` or \`mermaid\`.
+
+* \`elements\` should be a JSON-encoded string representing an **array of Excalidraw element objects** (same format produced by Excalidraw’s export feature). This list will replace the current scene.
+* \`mermaid\` should be a Mermaid diagram definition. It will be converted to Excalidraw elements before rendering.
+
+Only one of \`elements\` or \`mermaid\` is required.
 
 Guidelines:
-* Use absolute x, y only. Store the element’s top-left (for lines/arrows: start point) 
+* Use absolute x, y only. Store the element’s top-left (for lines/arrows: start point)
   in x and y. Do not encode absolute coordinates inside points.
 * Normalize the points array. For every linear element (line, arrow, draw), set
   points[0] = [0, 0]. All other points must be offsets from that origin:


### PR DESCRIPTION
## Summary
- extend canvas tool to accept `elements` or `mermaid`
- update canvas tool instructions for both formats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f799dda4832aabf0410e1d6b8073