### PR TITLE
Add canvas state tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - The audio-visualizer sidebar starts at 350 px and can be resized by dragging
   the vertical divider, letting you allocate more or less space to the canvas.
 - Includes an Excalidraw canvas controlled by the AI agent.
+- The canvas agent can read the current drawing via the `canvas_state` tool.
 
 ## Getting Started
 

--- a/app/hooks/useCanvasStateTool.test.tsx
+++ b/app/hooks/useCanvasStateTool.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { ExcalidrawContext } from "@/components/context/ExcalidrawContext.tsx";
+import useCanvasStateTool from "./useCanvasStateTool.ts";
+
+const mockElements = [{ id: '1', type: 'rectangle', x: 0, y: 0 }];
+
+describe("useCanvasStateTool", () => {
+    it("returns current scene as JSON", async () => {
+        const provider = ({ children }: { children: React.ReactNode }) => (
+            <ExcalidrawContext.Provider value={{ api: { getSceneElements: () => mockElements }, setApi: () => {} }}>
+                {children}
+            </ExcalidrawContext.Provider>
+        );
+        const { result } = renderHook(() => useCanvasStateTool(), { wrapper: provider });
+        const output = await result.current.invoke({} as any, "{}");
+        expect(output).toBe(JSON.stringify(mockElements));
+    });
+});

--- a/app/hooks/useCanvasStateTool.ts
+++ b/app/hooks/useCanvasStateTool.ts
@@ -1,0 +1,27 @@
+'use client';
+import { ExcalidrawContext } from "@/components/context/ExcalidrawContext.tsx";
+import { canvasStateToolInstructions } from "@/lib/prompts.ts";
+import { tool } from "@openai/agents-realtime";
+import { useContext, useMemo } from "react";
+import { z } from "zod";
+
+export default function useCanvasStateTool() {
+    const excalidraw = useContext(ExcalidrawContext);
+
+    return useMemo(
+        () =>
+            tool({
+                name: "canvas_state",
+                description: canvasStateToolInstructions,
+                parameters: z.object({}),
+                execute: async () => {
+                    if (!excalidraw?.api) {
+                        throw new Error("Canvas was not correctly initialized.");
+                    }
+                    const elements = excalidraw.api.getSceneElements();
+                    return JSON.stringify(elements);
+                },
+            }),
+        [excalidraw]
+    );
+}

--- a/app/hooks/useRealtime.ts
+++ b/app/hooks/useRealtime.ts
@@ -1,4 +1,5 @@
 import useCanvasTool from "@/hooks/useCanvasTool";
+import useCanvasStateTool from "@/hooks/useCanvasStateTool";
 import { generateEphemeralKey } from "@/lib/generateEphemeralKey.ts";
 import { assistantAgentInstructions, canvasAgentInstructions } from "@/lib/prompts.ts";
 import { Agent } from "@openai/agents";
@@ -13,6 +14,7 @@ export function useRealtime() {
     const sessionRef = useRef<RealtimeSession | null>(null);
 
     const canvasTool = useCanvasTool();
+    const canvasStateTool = useCanvasStateTool();
 
     /* create once */
     useEffect(() => {
@@ -23,7 +25,7 @@ export function useRealtime() {
         const canvasAgent = new Agent({
             name: "Canvas",
             model: "gpt-4.1",
-            tools: [canvasTool],
+            tools: [canvasTool, canvasStateTool],
             instructions: canvasAgentInstructions,
         });
 
@@ -39,7 +41,7 @@ export function useRealtime() {
         session.on("audio_start", () => setSpeaking(true));
         session.on("audio_stopped", () => setSpeaking(false));
         session.on("error", (e) => setErrored(String(e)));
-    }, [canvasTool]);
+    }, [canvasTool, canvasStateTool]);
 
     /* commands that UI can call */
     const connect = () => {

--- a/app/lib/prompts.ts
+++ b/app/lib/prompts.ts
@@ -8,6 +8,8 @@ export const canvasAgentInstructions = `
 You are “CanvasCoder”.  Whenever the user wants to draw or update the canvas,
 call the \`canvas\` tool.
 
+To see the current drawing, call the \`canvas_state\` tool.
+
 Guidelines
 ----------
 * You may use the Excalidraw canvas to express your ideas to the user. 
@@ -27,4 +29,8 @@ Guidelines:
 * Normalize the points array. For every linear element (line, arrow, draw), set
   points[0] = [0, 0]. All other points must be offsets from that origin:
   points[i] = [absX_i - x, absY_i - y].
+`;
+
+export const canvasStateToolInstructions = `
+Return the current Excalidraw scene as a JSON-encoded array of element objects.
 `;


### PR DESCRIPTION
## Summary
- allow the Canvas agent to check what has already been drawn
- update Canvas agent instructions and README
- test new hook for retrieving Excalidraw elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856fe572540832ab552581c747a0537