### PR TITLE
Add toast notifications for agent events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ lerna-debug.log*
 
 # NextJS
 /.next/
-/.env
+/.env.local
 node_modules
 dist
 dist-ssr

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ lerna-debug.log*
 
 # NextJS
 /.next/
-/.env.local
+/.env
 node_modules
 dist
 dist-ssr

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import { ExcalidrawProvider } from "../components/context/ExcalidrawContext.tsx";
 import { ReactNode } from "react";
+import { Toaster } from "sonner";
 
 import "./globals.css";
 
@@ -11,6 +12,7 @@ export default function RootLayout({
     return (
         <html lang="en"><body>
         <ExcalidrawProvider>{children}</ExcalidrawProvider>
+        <Toaster />
         </body></html>
     );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
     return (
         <html lang="en"><body>
         <ExcalidrawProvider>{children}</ExcalidrawProvider>
-        <Toaster />
+        <Toaster position="top-left"/>
         </body></html>
     );
 }

--- a/hooks/useRealtime.ts
+++ b/hooks/useRealtime.ts
@@ -4,6 +4,7 @@ import { assistantAgentInstructions, canvasAgentInstructions } from "../lib/ai/p
 import { Agent } from "@openai/agents";
 import { RealtimeAgent, RealtimeSession } from "@openai/agents-realtime";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 export function useRealtime() {
     const [errored, setErrored] = useState<boolean | string>(false);
@@ -39,6 +40,8 @@ export function useRealtime() {
         session.on("audio_start", () => setSpeaking(true));
         session.on("audio_stopped", () => setSpeaking(false));
         session.on("error", (e) => setErrored(String(e)));
+        session.on("agent_handoff", (_, _from, to) => toast(`Handoff to ${to.name}`));
+        session.on("agent_tool_start", (_, agent, tool) => toast(`${agent.name} uses ${tool.name}`));
     }, [canvasTool]);
 
     /* commands that UI can call */

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "openai": "^4.92.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "sonner": "^2.0.5",
         "tauri-plugin-macos-permissions-api": "^2.3.0"
       },
       "devDependencies": {
@@ -10949,6 +10950,16 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.5.tgz",
+      "integrity": "sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "openai": "^4.92.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "sonner": "^2.0.5",
     "tauri-plugin-macos-permissions-api": "^2.3.0"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- show a Sonner `<Toaster />` at the root
- display a toast when agents hand off or start a tool
- add `sonner` dependency

## Testing
- `npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6859fcafb61c832abc6a7388944a269f