### PR TITLE
Use npm package for Strudel

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import { ExcalidrawProvider } from "@/components/excalidraw/ExcalidrawContext.tsx";
+import { StrudelProvider } from "@/components/strudel/StrudelContext.tsx";
 import { ReactNode } from "react";
 import { Toaster } from "sonner";
 
@@ -12,7 +13,11 @@ export default function RootLayout({
     return (
         <html lang="en">
         <body>
-        <ExcalidrawProvider>{children}</ExcalidrawProvider>
+        <ExcalidrawProvider>
+        <StrudelProvider>
+            {children}
+        </StrudelProvider>
+        </ExcalidrawProvider>
         <Toaster position="top-left"/>
         </body>
         </html>

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,18 +1,26 @@
 "use client";
 
 import ExcalidrawCanvas from "@/components/excalidraw/ExcalidrawCanvas.tsx";
+import StrudelCanvas from "@/components/strudel/StrudelCanvas.tsx";
 import AudioVisualizer from "@/components/speech/AudioVisualizer";
 import ToggleListeningButton from "@/components/speech/ToggleListeningButton.tsx";
 import { useRealtimeAgent } from "@/hooks/useRealtimeAgent.ts";
 import React, { useEffect, useRef, useState } from "react";
 
 export default function Dashboard() {
-    const {listening, speaking, toggleListening, working} = useRealtimeAgent();
+    const {listening, speaking, toggleListening, working, lastTool} = useRealtimeAgent();
 
     const minSidebar = 100;
     const defaultSidebar = 350;
     const [sidebarWidth, setSidebarWidth] = useState(defaultSidebar);
+    const [activeTab, setActiveTab] = useState<'excalidraw' | 'strudel'>('excalidraw');
     const resizing = useRef(false);
+
+    useEffect(() => {
+        if (!lastTool) return;
+        if (lastTool.includes("Strudel")) setActiveTab('strudel');
+        if (lastTool.includes("Canvas")) setActiveTab('excalidraw');
+    }, [lastTool]);
 
     useEffect(() => {
         const onMouseMove = (e: MouseEvent) => {
@@ -46,8 +54,20 @@ export default function Dashboard() {
                 className="w-1 cursor-col-resize bg-gray-700"
                 onMouseDown={() => (resizing.current = true)}
             />
-            <div className="flex-1">
-                <ExcalidrawCanvas/>
+            <div className="flex-1 flex flex-col">
+                <div className="flex border-b border-gray-700">
+                    <button
+                        onClick={() => setActiveTab('excalidraw')}
+                        className={`px-4 py-2 ${activeTab==='excalidraw' ? 'text-white' : 'text-gray-400'}`}
+                    >Excalidraw</button>
+                    <button
+                        onClick={() => setActiveTab('strudel')}
+                        className={`px-4 py-2 ${activeTab==='strudel' ? 'text-white' : 'text-gray-400'}`}
+                    >Strudel</button>
+                </div>
+                <div className="flex-1 overflow-hidden">
+                    {activeTab === 'excalidraw' ? <ExcalidrawCanvas/> : <StrudelCanvas/>}
+                </div>
             </div>
         </div>
     );

--- a/components/speech/AudioVisualizer.test.tsx
+++ b/components/speech/AudioVisualizer.test.tsx
@@ -1,4 +1,4 @@
-import AudioVisualizer from "@/components/speech/AudioVisualizer.tsx";
+import AudioVisualizer from "./AudioVisualizer.tsx";
 import { render } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it } from "vitest";
@@ -14,7 +14,7 @@ describe("AudioVisualizer", () => {
     it("shows listening state when listening", () => {
         const {container} = render(<AudioVisualizer listening={true} speaking={false}/>);
         const div = container.firstElementChild as HTMLElement;
-        expect(div.className).toContain("bg-sky-600");
+        expect(div.className).toContain("from-fuchsia-400");
     });
 
     it("shows speaking state when speaking", () => {

--- a/components/strudel/StrudelCanvas.tsx
+++ b/components/strudel/StrudelCanvas.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { StrudelContext, StrudelEditor } from "./StrudelContext.tsx";
+import React, { useContext, useEffect, useRef } from "react";
+
+export default function StrudelCanvas() {
+  const ctx = useContext(StrudelContext);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    let mounted = true;
+    import("@strudel/repl").then(() => {
+      if (!mounted) return;
+      const el = document.createElement("strudel-editor") as StrudelEditor;
+      containerRef.current?.appendChild(el);
+      ctx?.setEditor(el);
+    });
+
+    return () => {
+      mounted = false;
+      ctx?.setEditor(null);
+      containerRef.current?.firstChild?.remove();
+    };
+  }, [ctx]);
+
+  return <div ref={containerRef} className="w-full h-full" />;
+}

--- a/components/strudel/StrudelContext.tsx
+++ b/components/strudel/StrudelContext.tsx
@@ -1,0 +1,20 @@
+"use client";
+import React, { createContext, useState, ReactNode } from "react";
+
+export type StrudelEditor = HTMLElement & { editor?: { evaluate: (code: string) => void } };
+
+interface Ctx {
+  editor: StrudelEditor | null;
+  setEditor: (editor: StrudelEditor | null) => void;
+}
+
+export const StrudelContext = createContext<Ctx | null>(null);
+
+export function StrudelProvider({ children }: { children: ReactNode }) {
+  const [editor, setEditor] = useState<StrudelEditor | null>(null);
+  return (
+    <StrudelContext.Provider value={{ editor, setEditor }}>
+      {children}
+    </StrudelContext.Provider>
+  );
+}

--- a/hooks/useRealtimeAgent.ts
+++ b/hooks/useRealtimeAgent.ts
@@ -1,4 +1,5 @@
 import useExcalidrawTools from "@/hooks/useExcalidrawTools.ts";
+import useStrudelTools from "@/hooks/useStrudelTools.ts";
 import { getToken } from "@/lib/ai/getToken.ts";
 import { RealtimeAgent, RealtimeSession } from "@openai/agents-realtime";
 import { useEffect, useRef, useState } from "react";
@@ -9,10 +10,13 @@ export function useRealtimeAgent() {
     const [listening, setListening] = useState(false);
     const [speaking, setSpeaking] = useState(false);
     const [working, setWorking] = useState(false);
+    const [lastTool, setLastTool] = useState<string | null>(null);
 
     const session = useRef<RealtimeSession | null>(null);
 
-    const tools = useExcalidrawTools();
+    const excalidrawTools = useExcalidrawTools();
+    const strudelTools = useStrudelTools();
+    const tools = [...excalidrawTools, ...strudelTools];
 
     /* create once */
     useEffect(() => {
@@ -23,7 +27,7 @@ export function useRealtimeAgent() {
         const assistantAgent = new RealtimeAgent({
             name: "Assistant",
             instructions:
-                "Use Excalidraw for any drawing-related tasks.",
+                "Use Excalidraw for drawing tasks and the Strudel Execute tool for music.",
             tools,
         });
 
@@ -45,6 +49,7 @@ export function useRealtimeAgent() {
         });
         session.current.on("agent_tool_start", (_, _agent, tool) => {
             setWorking(true);
+            setLastTool(tool.name);
             toast(`Using ${tool.name}`);
         });
 
@@ -73,5 +78,5 @@ export function useRealtimeAgent() {
     };
     const toggleListening = () => listening ? mute() : unmute();
 
-    return {errored, listening, speaking, toggleListening, working};
+    return {errored, listening, speaking, toggleListening, working, lastTool};
 }

--- a/hooks/useStrudelTools.test.tsx
+++ b/hooks/useStrudelTools.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import useStrudelTools from "./useStrudelTools.ts";
+import { StrudelContext, StrudelEditor } from "../components/strudel/StrudelContext.tsx";
+
+const wrapper = (editor: StrudelEditor | null) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <StrudelContext.Provider value={{ editor, setEditor: vi.fn() }}>
+      {children}
+    </StrudelContext.Provider>
+  );
+
+describe("useStrudelTools", () => {
+  it("evaluates code", async () => {
+    const evaluate = vi.fn();
+    const editor = { editor: { evaluate } } as StrudelEditor;
+    const { result } = renderHook(() => useStrudelTools(), { wrapper: wrapper(editor) });
+    await new Promise(r => setTimeout(r, 0));
+    const [tool] = result.current;
+    await tool.invoke({}, JSON.stringify({ code: "foo" }));
+    expect(evaluate).toHaveBeenCalledWith("foo");
+  });
+});

--- a/hooks/useStrudelTools.ts
+++ b/hooks/useStrudelTools.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { StrudelContext, StrudelEditor } from "../components/strudel/StrudelContext.tsx";
+import { tool } from "@openai/agents-realtime";
+import { useContext, useEffect, useMemo, useRef } from "react";
+import { z } from "zod";
+
+const schema = z.object({
+  code: z.string().describe("Strudel code to evaluate"),
+});
+
+export default function useStrudelTools() {
+  const ctx = useContext(StrudelContext);
+  const editorRef = useRef<StrudelEditor | null>(null);
+
+  useEffect(() => {
+    editorRef.current = ctx?.editor ?? null;
+  }, [ctx, ctx?.editor]);
+
+  const runCode = useMemo(
+    () =>
+      tool({
+        name: "Strudel Execute",
+        description: "Execute code in the Strudel music editor.",
+        parameters: schema,
+        strict: true,
+        execute: async ({ code }: z.infer<typeof schema>) => {
+          if (!editorRef.current) return "Editor not ready";
+          try {
+            // @ts-ignore
+            editorRef.current.editor?.evaluate(code);
+            return "ok";
+          } catch (err) {
+            console.error("strudel tool error:", err);
+            return err instanceof Error ? err.message : String(err);
+          }
+        },
+      }),
+    [editorRef]
+  );
+
+  return [runCode];
+}

--- a/lib/ai/getToken.test.ts
+++ b/lib/ai/getToken.test.ts
@@ -7,7 +7,7 @@ describe("getToken", () => {
     });
 
     it("calls OpenAI API and returns JSON", async () => {
-        const mockResponse = {session: "test"};
+        const mockResponse = {client_secret: {value: "test"}};
         const json = vi.fn().mockResolvedValue(mockResponse);
         global.fetch = vi.fn().mockResolvedValue({json} as never);
 
@@ -22,6 +22,6 @@ describe("getToken", () => {
                 "Content-Type": "application/json",
             })
         }));
-        expect(result).toEqual(mockResponse);
+        expect(result).toEqual("test");
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.0",
         "@openai/agents": "^0.0.8",
+        "@strudel/repl": "^1.2.3",
         "@tauri-apps/api": "^2.5.0",
         "@tauri-apps/plugin-fs": "^2.3.0",
         "@tauri-apps/plugin-opener": "^2.2.6",
@@ -120,6 +121,102 @@
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
       "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==",
       "license": "MIT"
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
+      "integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.0.tgz",
+      "integrity": "sha512-yvSchUwHOdupXkd7xJ0ob36jdsSR/I+/C+VbY0ffBiL5NiSTEBDfB1ZGWbbIlDd5xgdUkody+lukAdOxYrOBeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
@@ -1799,6 +1896,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
+      "integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.0.tgz",
@@ -1820,6 +1958,24 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@nanostores/persistent": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@nanostores/persistent/-/persistent-0.10.2.tgz",
+      "integrity": "sha512-BEndnLhRC+yP7gXTESepBbSj8XNl8OXK9hu4xAgKC7MWJHKXnEqJMqY47LUyHxK6vYgFnisyHmqq+vq8AUFyIg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2570,6 +2726,99 @@
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
       "license": "MIT"
     },
+    "node_modules/@replit/codemirror-emacs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-emacs/-/codemirror-emacs-6.1.0.tgz",
+      "integrity": "sha512-74DITnht6Cs6sHg02PQ169IKb1XgtyhI9sLD0JeOFco6Ds18PT+dkD8+DgXBDokne9UIFKsBbKPnpFRAz60/Lw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.0.2",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.1",
+        "@codemirror/view": "^6.3.0"
+      }
+    },
+    "node_modules/@replit/codemirror-vim": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.3.0.tgz",
+      "integrity": "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/commands": "6.x.x",
+        "@codemirror/language": "6.x.x",
+        "@codemirror/search": "6.x.x",
+        "@codemirror/state": "6.x.x",
+        "@codemirror/view": "6.x.x"
+      }
+    },
+    "node_modules/@replit/codemirror-vscode-keymap": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-vscode-keymap/-/codemirror-vscode-keymap-6.0.2.tgz",
+      "integrity": "sha512-j45qTwGxzpsv82lMD/NreGDORFKSctMDVkGRopaP+OrzSzv+pXDQuU3LnFvKpasyjVT0lf+PKG1v2DSCn/vxxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+      "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.44.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.0.tgz",
@@ -2863,6 +3112,145 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@strudel/codemirror": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@strudel/codemirror/-/codemirror-1.2.2.tgz",
+      "integrity": "sha512-uGB+krWvEJ+AgVV+clqJv1zoNcsdr3Gps13XbwCgHWeAoHnmvJhQvniyE1y0YPx7moCMiAM1cShEVqDddzTp3w==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.18.4",
+        "@codemirror/commands": "^6.8.0",
+        "@codemirror/lang-javascript": "^6.2.2",
+        "@codemirror/language": "^6.10.8",
+        "@codemirror/search": "^6.5.8",
+        "@codemirror/state": "^6.5.1",
+        "@codemirror/view": "^6.36.2",
+        "@lezer/highlight": "^1.2.1",
+        "@nanostores/persistent": "^0.10.2",
+        "@replit/codemirror-emacs": "^6.1.0",
+        "@replit/codemirror-vim": "^6.2.1",
+        "@replit/codemirror-vscode-keymap": "^6.0.2",
+        "@strudel/core": "1.2.2",
+        "@strudel/draw": "1.2.2",
+        "@strudel/transpiler": "1.2.2",
+        "nanostores": "^0.11.3"
+      }
+    },
+    "node_modules/@strudel/core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@strudel/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-rPFAwV7Emz85HyKwfVVn+2cNOHCGBbWw6XImv0elnzRiXxKWMdmZfuSL3xgpheEg9WUgacgmzJL9kbvfCitGtA==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "fraction.js": "^5.2.1"
+      }
+    },
+    "node_modules/@strudel/draw": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@strudel/draw/-/draw-1.2.2.tgz",
+      "integrity": "sha512-0Vmva6lc51L4rDcLwpGeoQ14t1/2RoyzhI6Sfa3drTALa69E3Jg2bn4o/sZgaifNRkPJhbIOdCqIVcir69Aj6w==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.2"
+      }
+    },
+    "node_modules/@strudel/hydra": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@strudel/hydra/-/hydra-1.2.2.tgz",
+      "integrity": "sha512-W8ZX50gb+wYx2SzI+c0UDjJNa6F0k+W2j6xgbazH/Y2MAot6zGVMwVsOXxpaL5ZOEN0jJ/W+h6EPdkiVVFUS9A==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.2",
+        "@strudel/draw": "1.2.2",
+        "hydra-synth": "^1.3.29"
+      }
+    },
+    "node_modules/@strudel/midi": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@strudel/midi/-/midi-1.2.3.tgz",
+      "integrity": "sha512-6WClxFeEcDQ4E6Vp6T0EsuL/Q98cUqT/++GeG13ntkCumnGoLYcHye/B62YW8mYDoW1UfBJwpYHIqtVO3FunGg==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.2",
+        "@strudel/webaudio": "1.2.3",
+        "webmidi": "^3.1.12"
+      }
+    },
+    "node_modules/@strudel/mini": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@strudel/mini/-/mini-1.2.2.tgz",
+      "integrity": "sha512-kMGdAp6J6dI6oZijQdobVn/STt8bNQkMNcwe341E2gnRvz3S3KbYAKRVvAKrm9jFzy1zoL4F+a1BnqoOqlOPDw==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.2"
+      }
+    },
+    "node_modules/@strudel/repl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@strudel/repl/-/repl-1.2.3.tgz",
+      "integrity": "sha512-9zMDIeZPn3mxroTv/87AyZWll145vi3b1Oi1k+YGCJdENH3zM5UKrNNJPXwpvO7O28Tod1oYuxj04a2MExz9aw==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/codemirror": "1.2.2",
+        "@strudel/core": "1.2.2",
+        "@strudel/draw": "1.2.2",
+        "@strudel/hydra": "1.2.2",
+        "@strudel/midi": "1.2.3",
+        "@strudel/mini": "1.2.2",
+        "@strudel/soundfonts": "1.2.3",
+        "@strudel/tonal": "1.2.2",
+        "@strudel/transpiler": "1.2.2",
+        "@strudel/webaudio": "1.2.3"
+      }
+    },
+    "node_modules/@strudel/soundfonts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@strudel/soundfonts/-/soundfonts-1.2.3.tgz",
+      "integrity": "sha512-uLIJfWMnENwXBe2PuhrrP6GIu21RLtgmCzaZMxBc/U+NrlLQquKc9TAQKH5narPXYFnEYPXB8JLylEcGAG2OXA==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.2",
+        "@strudel/webaudio": "1.2.3",
+        "sfumato": "^0.1.2",
+        "soundfont2": "^0.5.0"
+      }
+    },
+    "node_modules/@strudel/tonal": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@strudel/tonal/-/tonal-1.2.2.tgz",
+      "integrity": "sha512-p09mb2gHZj0NXYbDyuXAK2NQZtrm6n589kE2JdlBTUuxtHHzyNzHzE3WeuGur2QY7avjwM5mw3kPnelstLTQVw==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.2",
+        "@tonaljs/tonal": "^4.10.0",
+        "chord-voicings": "^0.0.1",
+        "webmidi": "^3.1.12"
+      }
+    },
+    "node_modules/@strudel/transpiler": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@strudel/transpiler/-/transpiler-1.2.2.tgz",
+      "integrity": "sha512-UGz+nsM3ZSQ1pQD5KPEyYxSBPLyEySc9YCyjN5xiDNdxrBOEKpSgtj1Fj5NzVNlzfuhX+ao6GveZvKqSE4T64g==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.2",
+        "@strudel/mini": "1.2.2",
+        "acorn": "^8.14.0",
+        "escodegen": "^2.1.0",
+        "estree-walker": "^3.0.3"
+      }
+    },
+    "node_modules/@strudel/webaudio": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@strudel/webaudio/-/webaudio-1.2.3.tgz",
+      "integrity": "sha512-d+69P3fC9LFKkF4BXxnb99p+Vj51d094ywbgPhuRfw22sNkIPA49Xma6+Nft+NIpX0kFz6XL/gr1sDYF2z8M+A==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.2",
+        "@strudel/draw": "1.2.2",
+        "superdough": "1.2.3"
+      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -3489,6 +3877,462 @@
         }
       }
     },
+    "node_modules/@tonaljs/abc-notation": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/abc-notation/-/abc-notation-4.9.1.tgz",
+      "integrity": "sha512-2fDUdPsFDdgZgyIiZCTYGKy30QiwIQxSXCSN2thGrSMXbQKCp8iTC8haStYcrA+25MPWhWlmvC/pz3tGcTNAqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/array": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/array/-/array-4.8.4.tgz",
+      "integrity": "sha512-97HVdpZy82PqNBDMM9PRSbO2DUrnxNg3++N4xqLpfby70fKHAHhTWrMXWZK+Dzs76HDPQLd+qhd4cq28eBZzjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/chord": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord/-/chord-4.10.2.tgz",
+      "integrity": "sha512-Zlqtq6c6T4y+EqvwHRQp9icEjHqyniCpnIwwCFg5amgAQwXmWzarouOOSmcdJ1Is92eEvcPVuCoLiVUtajS30A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-detect": "^4.8.1",
+        "@tonaljs/chord-type": "^4.8.2",
+        "@tonaljs/collection": "^4.8.0",
+        "@tonaljs/core": "^4.10.0",
+        "@tonaljs/pcset": "^4.8.2",
+        "@tonaljs/scale-type": "^4.8.2"
+      }
+    },
+    "node_modules/@tonaljs/chord-detect": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-detect/-/chord-detect-4.9.1.tgz",
+      "integrity": "sha512-rV/9+R7aZ9cQorQ3jdNMMMh63onosglYZM71Q0n7KKcWMAGrxF66MzxBG82xy+w1QDMJQslB3iHfDHUiS6wRjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/chord-detect/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/chord-type": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-4.8.2.tgz",
+      "integrity": "sha512-GzSTjQmZjkUdPhyesFDeJbxpW8R7L/bAE34E8ApGAh9FMcKYpRdX3Tn+gkluRsXOiRMfW07p3E0Adx4bjtyN+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.8.0",
+        "@tonaljs/pcset": "^4.8.2"
+      }
+    },
+    "node_modules/@tonaljs/collection": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/collection/-/collection-4.9.0.tgz",
+      "integrity": "sha512-Mk0h7O54nT6PgNVcUYauzxa5KOB23+0AOKudWzRH7JhJIN9vhVIC7PtwZXE+/G051UTbHSFIcN/afkgF4nB/8A==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/core": {
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/core/-/core-4.10.4.tgz",
+      "integrity": "sha512-PhGlQ2Js6rFQ6CufkSiBpEJoPS8QIIhbXSXhT4U+5ffqckli+YBZRN24vjZ4AEKuX8xoYDmCCbl+r6agauvzmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1",
+        "@tonaljs/pitch-distance": "5.0.2",
+        "@tonaljs/pitch-interval": "5.0.2",
+        "@tonaljs/pitch-note": "5.0.3"
+      }
+    },
+    "node_modules/@tonaljs/core/node_modules/@tonaljs/pitch-distance": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-distance/-/pitch-distance-5.0.2.tgz",
+      "integrity": "sha512-DPxfGJCf4BvfIVRxl2v142tuCKIziM6PomOBT0/s7U5o+Z5qFAIW0tNx/MKyL83guV74p+XIf5VI0w1flmXxDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1",
+        "@tonaljs/pitch-interval": "5.0.2",
+        "@tonaljs/pitch-note": "5.0.3"
+      }
+    },
+    "node_modules/@tonaljs/core/node_modules/@tonaljs/pitch-note": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-note/-/pitch-note-5.0.3.tgz",
+      "integrity": "sha512-JsPgqPa8VZdZtfwvgoHJz996BZqzvlnRxUF6c/Q9q8E0iq30UHBEid0Y6XldK+h6tuIENsG3a9jyvNNxRqIeYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1"
+      }
+    },
+    "node_modules/@tonaljs/duration-value": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/duration-value/-/duration-value-4.9.0.tgz",
+      "integrity": "sha512-Muz54HyIe0nMYKWx6wyTa4y17ma29DtpJF4/oqJphy6A124rAVDe/SKit8JGOvDYAQj71FUXqs17sXBxO/ExVw==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/interval": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-4.8.2.tgz",
+      "integrity": "sha512-9SEuJuqFdmu9lnvMmJtxbReQcQvZ1YHXhCcxaF6Re23/w+BqiJvvkvNZhfWH+n1+g0uaSdTsuvMfamp7hAvPMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.1",
+        "@tonaljs/pitch-distance": "^5.0.2",
+        "@tonaljs/pitch-interval": "^5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/key": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/key/-/key-4.11.2.tgz",
+      "integrity": "sha512-fc1y5+NwS4S3amirzYLLB324PxJDO00oIBbLJclAddc46UBeYnu4FNz+1nZboHCXRQ/06/ftuaWD/l7HrAoulw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/roman-numeral": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/midi": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/midi/-/midi-4.10.2.tgz",
+      "integrity": "sha512-MPamXhEwPL7L1udLfYMm3Ft8mLYtHr62Zi2w5zYHM2P7YwIvNoiX0+dvAN5is1Wvq4iVRa8AjFHerjOW/SZhGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/mode": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/mode/-/mode-4.9.1.tgz",
+      "integrity": "sha512-h+K7eOUKpyX7kMRCwCew6cV1oN0sZYD5LLeKD7zEERNd/6wvGBfGCdMZECGqzpFUmjUyCY87IOntem6EPbKVCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/interval": "5.1.0",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/interval": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-5.1.0.tgz",
+      "integrity": "sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.2",
+        "@tonaljs/pitch-distance": "^5.0.4",
+        "@tonaljs/pitch-interval": "^6.0.0"
+      }
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/note": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/note/-/note-4.12.1.tgz",
+      "integrity": "sha512-yh6cnhu21bUb0VuIQWxObSbWBVp2cHIkJj4zZ4qsNOW4jSqn74+wHpSbOTDF8q+2hl6upz7TtBRavtqwPtLUCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/midi": "4.10.2",
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/note/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/note/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pcset": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pcset/-/pcset-4.10.1.tgz",
+      "integrity": "sha512-CZG1rpKc38yMfpEJsbDTvsTmQqsek9xxcuMgK64Tr6sP1lEiDuZJbQeKVWWRnreBF2FQ1cEGLmfOpvSO+40csA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pcset/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pcset/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.1.tgz",
+      "integrity": "sha512-5HYkF4hGY0jS2y5V3Hf5gNFXX46kT4cAcI7JLEn+qQb9N1dU9Gz9koI9di0mD1Tbam+kviceiCsJl4WX/FqYjA==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pitch-distance": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-distance/-/pitch-distance-5.0.5.tgz",
+      "integrity": "sha512-dTfjsU0zyrj5YmiFio5prPaD5w7sBmHp4nnmlEg70nHY+SerAH0KiO9HM9usttVgRFUaXl0Gc7OI8YMGfSFmug==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pitch-distance/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pitch-distance/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch-interval": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-5.0.2.tgz",
+      "integrity": "sha512-bQmxeenRFNuuABs9mDc+bSUp3ySGw8I49pHMoGDdCcro9n3MDN8IsSwhvKoGOYErFMx76rNn1t+7WL8ukpvX5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1"
+      }
+    },
+    "node_modules/@tonaljs/pitch-note": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-note/-/pitch-note-6.1.0.tgz",
+      "integrity": "sha512-A4OSLo8DjM38u73862LnDmL4YInDDRBmg0fojXcvu4cyU3oOlqndyeHOra1OVoH/WW46uNIxNs1wJDZNPWL5KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch-note/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/progression": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/progression/-/progression-4.9.1.tgz",
+      "integrity": "sha512-jHdZUNlXRmjrvbZrvjoW6syW7dO9ilhgvyouB6YuVM5lGShwTN9dsSuQYsugso9jYHkwQBgYj5SaXTTY0/0nHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord": "6.1.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/roman-numeral": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/chord": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord/-/chord-6.1.1.tgz",
+      "integrity": "sha512-gsLyGGkOt0g5L/uF4ICpYQengahW3WAMjckyvyzvqMYpvH7fokmtcymOfbltDQzaVuYuL0TsVmbfjbah2rKEww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-detect": "4.9.1",
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/interval": "^5.1.0",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/interval": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-5.1.0.tgz",
+      "integrity": "sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.2",
+        "@tonaljs/pitch-distance": "^5.0.4",
+        "@tonaljs/pitch-interval": "^6.0.0"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/range": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/range/-/range-4.9.2.tgz",
+      "integrity": "sha512-XhFbCJCrEEIVz3MNmdVp9QUyiJA6eqnNnQeNqto8AuT5BYuffHDoMkBmvvjPuV5Lh8zfF9D0aqglvqPbZ+neKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/midi": "4.10.2"
+      }
+    },
+    "node_modules/@tonaljs/roman-numeral": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/roman-numeral/-/roman-numeral-4.9.1.tgz",
+      "integrity": "sha512-dJGKBNHdPrNTE97ZDk4t6wpNmgYcpHyLkAvWkRP9I/HsDkeTFFQqNXosYIvspPWrFySlRpeqqFwcqV74MYoOag==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/roman-numeral/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/roman-numeral/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/scale": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@tonaljs/scale/-/scale-4.13.3.tgz",
+      "integrity": "sha512-IcPMpOm6gMQJ3A2IXZ5dN0wOhHIUonQY8abTql4BrwcVCUaItXWQfSd9t1HII+2kA6J8JCeY2BukTr6wVwAhXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/scale-type": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/scale-type/-/scale-type-4.9.1.tgz",
+      "integrity": "sha512-Nz2wThzz5NmWNx0vazX7MqNbF8kT1g5BEcbZcWjgkc67zhwosfZE0LEn7W9XcVDEws71b8CqQqDPKUEEybC9Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/scale/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/time-signature": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/time-signature/-/time-signature-4.9.0.tgz",
+      "integrity": "sha512-zRo8CBqg/2guzTlF2vxyVIuB5gmwWQaxlknJPUSDII8CTdQ/x3a1LlNoMKkvTUnqwCihe3WrNPZ5XUfOOTthYA==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/tonal": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/tonal/-/tonal-4.10.0.tgz",
+      "integrity": "sha512-F2T9Fiy+j0MVped89kCrX1XF68mQOLUnny4pDOHrIf+OkrjtLQOzzaSOrX1tx0o72WUwQm1knz6D1d57b9X1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/abc-notation": "^4.8.0",
+        "@tonaljs/array": "^4.8.0",
+        "@tonaljs/chord": "^4.8.0",
+        "@tonaljs/chord-type": "^4.8.0",
+        "@tonaljs/collection": "^4.8.0",
+        "@tonaljs/core": "^4.8.0",
+        "@tonaljs/duration-value": "^4.8.0",
+        "@tonaljs/interval": "^4.8.0",
+        "@tonaljs/key": "^4.9.0",
+        "@tonaljs/midi": "^4.8.0",
+        "@tonaljs/mode": "^4.8.0",
+        "@tonaljs/note": "^4.9.0",
+        "@tonaljs/pcset": "^4.8.0",
+        "@tonaljs/progression": "^4.8.0",
+        "@tonaljs/range": "^4.8.0",
+        "@tonaljs/roman-numeral": "^4.8.0",
+        "@tonaljs/scale": "^4.9.0",
+        "@tonaljs/scale-type": "^4.8.0",
+        "@tonaljs/time-signature": "^4.8.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -3559,7 +4403,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3630,11 +4473,24 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/unist": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "node_modules/@types/webmidi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.1.0.tgz",
+      "integrity": "sha512-k898MjEUSHB+6rSeCPQk/kLgie0wgWZ2t78GlWj86HbTQ+XmtbBafYg5LNjn8bVHfItEhPGZPf579Xfc6keV6w==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -4382,7 +5238,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4750,6 +5605,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-plugin-add-module-exports": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
+      "integrity": "sha512-3AN/9V/rKuv90NG65m4tTHsI04XrCKsWbztIcW7a8H5iIN7WlvWucRtVV0V/rT4QvtA11n5Vmp20fLwfMWqp6g==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4818,6 +5679,34 @@
       "resolved": "https://registry.npmjs.org/browser-fs-access/-/browser-fs-access-0.29.1.tgz",
       "integrity": "sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -5025,6 +5914,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chord-voicings": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/chord-voicings/-/chord-voicings-0.0.1.tgz",
+      "integrity": "sha512-SutgB/4ynkkuiK6qdQ/k3QvCFcH0Vj8Ch4t6LbRyRQbVzP/TOztiCk3kvXd516UZ6fqk7ijDRELEFcKN+6V8sA==",
+      "license": "ISC",
+      "dependencies": {
+        "@tonaljs/tonal": "^4.6.5"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -5166,6 +6064,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -5197,6 +6101,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -5841,6 +6751,15 @@
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
+    "node_modules/dct": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dct/-/dct-0.1.0.tgz",
+      "integrity": "sha512-/uUtEniuMq1aUxvLAoDtAduyl12oM1zhA/le2f83UFN/9+4KDHXFB6znEfoj5SDDLiTpUTr26NpxC7t8IFOYhQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -5894,6 +6813,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -5991,6 +6919,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/djipevents": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/djipevents/-/djipevents-2.0.7.tgz",
+      "integrity": "sha512-KNFYaU85imxOCKOUsIR70Iz9E19r96/X7LSH+u0tSoZdpWcBdzoqtTsU+wuLhc6GMpSFob+KInkZAbfKi01Bjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/doctrine": {
@@ -6339,6 +7276,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -6701,6 +7659,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -6731,7 +7702,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -6741,7 +7711,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -6751,7 +7720,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6774,6 +7742,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/eventsource": {
@@ -6967,6 +7944,15 @@
         }
       }
     },
+    "node_modules/fftjs": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fftjs/-/fftjs-0.0.4.tgz",
+      "integrity": "sha512-nIWxQyth1LVD6NH8a+YZUv+McjzbOY6dMe4wv6Pq5cGfP+c8Rd1T8Dsd50DCWlNgzSqA3y9lOkpD6dZD3qHa1A==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-add-module-exports": "^0.2.1"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -7107,6 +8093,19 @@
       "optional": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.2.2.tgz",
+      "integrity": "sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fractional-indexing": {
@@ -7510,6 +8509,17 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/hydra-synth": {
+      "version": "1.3.29",
+      "resolved": "https://registry.npmjs.org/hydra-synth/-/hydra-synth-1.3.29.tgz",
+      "integrity": "sha512-KK1wMGpo9AuVivvD9SP7ukPS7T/rMaYA7XMlnRF3oFbTw9u4l4aVTyexG+KmCd5XDD/4GulR1jVzySZlAuGPCw==",
+      "license": "AGPL",
+      "dependencies": {
+        "meyda": "^5.5.1",
+        "raf-loop": "^1.1.3",
+        "regl": "^1.3.9"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -7744,7 +8754,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7859,6 +8868,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "license": "MIT"
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
@@ -8089,6 +9104,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jazz-midi": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/jazz-midi/-/jazz-midi-1.7.9.tgz",
+      "integrity": "sha512-c8c4BBgwxdsIr1iVm53nadCrtH7BUlnX3V95ciK/gbvXN/ndE5+POskBalXgqlc/r9p2XUbdLTrgrC6fou5p9w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
@@ -8262,6 +9287,17 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jzz": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/jzz/-/jzz-1.9.3.tgz",
+      "integrity": "sha512-DXQ7xXuJzC4YxNbQZy9pfHC/DOXM6IHgceTXnkhk1/+lU/qDk8W9xUaNpgCH6t1QDQ9roz7FSVtFc0/JhYQFxg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/webmidi": "^2.1.0",
+        "jazz-midi": "^1.7.9"
       }
     },
     "node_modules/katex": {
@@ -8786,6 +9822,25 @@
         "ts-dedent": "^2.2.0",
         "uuid": "^9.0.0",
         "web-worker": "^1.2.0"
+      }
+    },
+    "node_modules/meyda": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/meyda/-/meyda-5.6.3.tgz",
+      "integrity": "sha512-fAdwfzIi1WDoL0idUQvCD7dZ7EN74FYH83G+jZQO3Nr9yOEBtzFvcMg2KLdLlu6psSP8XFlO0kYynG5o/E681Q==",
+      "license": "MIT",
+      "workspaces": [
+        "docs"
+      ],
+      "dependencies": {
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "dct": "0.1.0",
+        "fftjs": "0.0.4",
+        "node-getopt": "^0.3.2",
+        "wav": "^1.0.2"
+      },
+      "bin": {
+        "meyda": "bin/cli.js"
       }
     },
     "node_modules/micromark": {
@@ -9383,6 +10438,21 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nanostores": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.11.4.tgz",
+      "integrity": "sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
@@ -9508,6 +10578,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-getopt": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.3.2.tgz",
+      "integrity": "sha512-yqkmYrMbK1wPrfz7mgeYvA4tBperLg9FQ4S3Sau3nSAkpOA0x0zC8nQ1siBwozy1f4SE8vq2n1WKv99r+PCa1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/non-layered-tidy-tree-layout": {
@@ -9867,7 +10946,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
@@ -9903,6 +10981,12 @@
       "integrity": "sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==",
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
+    },
     "node_modules/pica": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/pica/-/pica-7.1.1.tgz",
@@ -9926,7 +11010,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10157,6 +11240,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "node_modules/raf-loop": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/raf-loop/-/raf-loop-1.1.3.tgz",
+      "integrity": "sha512-fcIuuIdjbD6OB0IFw4d+cjqdrzDorKkIpwOiSnfU4Tht5PTFiJutR8hnCOGslYqZDyIzwpF5WnwbnTTuo9uUUA==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^1.0.2",
+        "inherits": "^2.0.1",
+        "raf": "^3.0.0",
+        "right-now": "^1.0.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10280,6 +11384,24 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -10348,11 +11470,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.7.0.tgz",
+      "integrity": "sha512-bEAtp/qrtKucxXSJkD4ebopFZYP0q1+3Vb2WECWv/T8yQEgKxDxJ7ztO285tAMaYZVR6mM1GgI6CCn8FROtL1w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -10400,6 +11527,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/right-now": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
+      "license": "MIT"
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
@@ -10410,7 +11543,7 @@
       "version": "4.44.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
       "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10776,6 +11909,21 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/sfumato": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/sfumato/-/sfumato-0.1.2.tgz",
+      "integrity": "sha512-j2s5BLUS5VUNtaK1l+v+yal3XjjV7JXCQIwE5Xs4yiQ3HJ+2Fc/dd3IkkrVHn0AJO2epShSWVoP3GnE0TvPdMg==",
+      "license": "ISC",
+      "dependencies": {
+        "soundfont2": "^0.4.0"
+      }
+    },
+    "node_modules/sfumato/node_modules/soundfont2": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/soundfont2/-/soundfont2-0.4.0.tgz",
+      "integrity": "sha512-537WiurDBRbDLVhJMxXLE06D6yWxJCidfPClnibZ0f8dKMDpv+0fIfwCQ8pELE0JqKX05SOJosNJgKzQobaAEA==",
+      "license": "MIT"
+    },
     "node_modules/sharp": {
       "version": "0.34.2",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz",
@@ -10961,6 +12109,22 @@
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/soundfont2": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/soundfont2/-/soundfont2-0.5.0.tgz",
+      "integrity": "sha512-dcmNVtHT/Y8BOOrtmjt7hn6Bk6bB1g+O2bWB9fa6emW7kfwiEiEL4VvGQfwVt8g0m58LyoqVyuQ4ZFukMLwGHQ==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -11015,6 +12179,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -11022,6 +12210,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -11179,6 +12373,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -11208,6 +12408,15 @@
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
     },
+    "node_modules/superdough": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/superdough/-/superdough-1.2.3.tgz",
+      "integrity": "sha512-OoTHb1wRdoqmQKU21p8bAe8l0xMk4VYJJRlfGxDAo176a2USLubxNTUpgD0jv/W71U6BVTzYIt/5tkmD3p2eXA==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "nanostores": "^0.11.3"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11225,7 +12434,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12050,6 +13258,12 @@
         }
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -12062,6 +13276,34 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/wav": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wav/-/wav-1.0.2.tgz",
+      "integrity": "sha512-viHtz3cDd/Tcr/HbNqzQCofKdF6kWUymH9LGDdskfWFoIy/HJ+RTihgjEcHfnsy1PO4e9B+y4HwgTwMrByquhg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc": "^1.1.0",
+        "buffer-from": "^1.0.0",
+        "debug": "^2.2.0",
+        "readable-stream": "^1.1.14",
+        "stream-parser": "^0.3.1"
+      }
+    },
+    "node_modules/wav/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/wav/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
@@ -12083,6 +13325,21 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webmidi": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-3.1.12.tgz",
+      "integrity": "sha512-X1lACggXm2BxuAPdx5wleh8S2kygduHbtR2ti5sGhivLkX6Muv/sLAYmPuIaNLOUddyxr71+3tsq8m5dKXoT4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "djipevents": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=8.5"
+      },
+      "optionalDependencies": {
+        "jzz": "^1.8.5"
+      }
     },
     "node_modules/webworkify": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@excalidraw/excalidraw": "^0.18.0",
     "@openai/agents": "^0.0.8",
+    "@strudel/repl": "^1.2.3",
     "@tauri-apps/api": "^2.5.0",
     "@tauri-apps/plugin-fs": "^2.3.0",
     "@tauri-apps/plugin-opener": "^2.2.6",


### PR DESCRIPTION
## Summary
- install `@strudel/repl`
- load Strudel REPL from npm instead of CDN

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68605fbb4350832a8e819e4240395065