### PR TITLE
Add text input support

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -2,16 +2,19 @@
 
 import ExcalidrawCanvas from "@/components/excalidraw/ExcalidrawCanvas.tsx";
 import AudioVisualizer from "@/components/speech/AudioVisualizer";
+import TextInput from "@/components/speech/TextInput.tsx";
 import ToggleListeningButton from "@/components/speech/ToggleListeningButton.tsx";
+import { KeyboardIcon } from "@/components/icons/KeyboardIcon.tsx";
 import { useRealtimeAgent } from "@/hooks/useRealtimeAgent.ts";
 import React, { useEffect, useRef, useState } from "react";
 
 export default function Dashboard() {
-    const {listening, speaking, toggleListening, working} = useRealtimeAgent();
+    const {listening, speaking, toggleListening, working, sendMessage} = useRealtimeAgent();
 
     const minSidebar = 100;
     const defaultSidebar = 350;
     const [sidebarWidth, setSidebarWidth] = useState(defaultSidebar);
+    const [showInput, setShowInput] = useState(false);
     const resizing = useRef(false);
 
     useEffect(() => {
@@ -32,15 +35,25 @@ export default function Dashboard() {
     return (
         <div className="flex w-screen h-screen bg-black">
             <div
-                className="relative flex items-center justify-center flex-none"
+                className="relative flex flex-col items-center flex-none"
                 style={{width: `${sidebarWidth}px`}}
             >
-                <AudioVisualizer listening={listening} speaking={speaking} working={working}/>
+                <div className={showInput ? "flex items-center justify-center flex-1" : "flex items-center justify-center h-full"}>
+                    <AudioVisualizer listening={listening} speaking={speaking} working={working}/>
+                </div>
+                {showInput && <TextInput sendMessage={sendMessage}/>} 
 
                 <ToggleListeningButton
                     listening={listening}
                     toggleListening={toggleListening}
                 />
+                <button
+                    onClick={() => setShowInput(v => !v)}
+                    className="absolute bottom-4 left-4 flex items-center justify-center h-12 w-12 rounded-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg"
+                >
+                    <KeyboardIcon className="size-6" />
+                    <span className="sr-only">Toggle text input</span>
+                </button>
             </div>
             <div
                 className="w-1 cursor-col-resize bg-gray-700"

--- a/components/icons/KeyboardIcon.tsx
+++ b/components/icons/KeyboardIcon.tsx
@@ -1,0 +1,22 @@
+import { SVGProps } from "react";
+
+export function KeyboardIcon(props: SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={24}
+            height={24}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="lucide lucide-keyboard-icon"
+            {...props}
+        >
+            <rect x="2" y="4" width="20" height="16" rx="2"/>
+            <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h12M6 16h12"/>
+        </svg>
+    );
+}

--- a/components/speech/TextInput.tsx
+++ b/components/speech/TextInput.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React, { FormEvent, useState } from "react";
+
+interface Props {
+    sendMessage: (text: string) => void;
+}
+
+export default function TextInput({ sendMessage }: Props) {
+    const [value, setValue] = useState("");
+
+    const onSubmit = (e: FormEvent) => {
+        e.preventDefault();
+        const trimmed = value.trim();
+        if (!trimmed) return;
+        sendMessage(trimmed);
+        setValue("");
+    };
+
+    return (
+        <form onSubmit={onSubmit} className="flex gap-2 p-2 border-t border-gray-700">
+            <input
+                type="text"
+                className="flex-1 rounded px-2 py-1 text-black"
+                placeholder="Type your request..."
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+            />
+            <button
+                type="submit"
+                className="px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+            >
+                Send
+            </button>
+        </form>
+    );
+}

--- a/hooks/useRealtimeAgent.ts
+++ b/hooks/useRealtimeAgent.ts
@@ -79,5 +79,10 @@ export function useRealtimeAgent() {
     };
     const toggleListening = () => listening ? mute() : unmute();
 
-    return {errored, listening, speaking, toggleListening, working};
+    const sendMessage = (text: string) => {
+        if (!text) return;
+        session.current?.sendMessage(text);
+    };
+
+    return {errored, listening, speaking, toggleListening, working, sendMessage};
 }


### PR DESCRIPTION
## Summary
- allow text messages with sendMessage()
- add keyboard icon and TextInput component
- update Dashboard to show text input toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68608e813e48832a9ebb3b2949ab1672