### PR TITLE
Add documentation to key components

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,9 @@ import { Toaster } from "sonner";
 
 import "./globals.css";
 
+/**
+ * Global layout wrapper used by Next.js. Sets up providers and the UI chrome.
+ */
 export default function RootLayout({
     children,
 }: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,9 @@ import { useEffect } from "react";
 
 import { checkMicrophonePermission, requestMicrophonePermission } from "tauri-plugin-macos-permissions-api";
 
+/**
+ * Entry page that requests microphone permissions and renders the dashboard.
+ */
 export default function HomePage() {
     useEffect(() => {
         checkMicrophonePermission().then(checkMicrophonePermission => {

--- a/components/dashboard/Dashboard.tsx
+++ b/components/dashboard/Dashboard.tsx
@@ -8,6 +8,9 @@ import ToggleListeningButton from "@/components/speech/ToggleListeningButton.tsx
 import { useRealtimeAgent } from "@/hooks/useRealtimeAgent.ts";
 import React, { useEffect, useRef, useState } from "react";
 
+/**
+ * Main application dashboard with drawing tools and realtime assistant.
+ */
 export default function Dashboard() {
     const {listening, speaking, toggleListening, working} = useRealtimeAgent();
 

--- a/components/excalidraw/ExcalidrawCanvas.tsx
+++ b/components/excalidraw/ExcalidrawCanvas.tsx
@@ -4,6 +4,9 @@ import { ToolContext } from "../tool/ToolContext.tsx";
 import ExcalidrawWrapper from "components/excalidraw/ExcalidrawWrapper.tsx";
 import React, { useContext } from "react";
 
+/**
+ * Container component that exposes the Excalidraw API via context.
+ */
 export default function ExcalidrawCanvas() {
     const ctx = useContext(ToolContext);
 

--- a/components/excalidraw/ExcalidrawWrapper.tsx
+++ b/components/excalidraw/ExcalidrawWrapper.tsx
@@ -13,6 +13,9 @@ const ExcalidrawLazy = dynamic(
     ExcalidrawProps & RefAttributes<ExcalidrawImperativeAPI>
 >;
 
+/**
+ * Loads the heavy Excalidraw component lazily and forwards its ref.
+ */
 const ExcalidrawWrapper = forwardRef<
     ExcalidrawImperativeAPI,
     ExcalidrawProps

--- a/components/icons/MicIcon.tsx
+++ b/components/icons/MicIcon.tsx
@@ -1,5 +1,9 @@
 import { SVGProps } from "react";
 
+/**
+ * Simple microphone SVG icon used throughout the UI.
+ */
+
 export function MicIcon(props: SVGProps<SVGSVGElement>) {
     return (
         <svg

--- a/components/lexical/LexicalCanvas.tsx
+++ b/components/lexical/LexicalCanvas.tsx
@@ -22,6 +22,9 @@ import { ParagraphNode, TabNode, TextNode } from "lexical";
 import React, { useContext, useEffect } from "react";
 import { ToolContext } from "../tool/ToolContext.tsx";
 
+/**
+ * Helper component that exposes the Lexical editor instance via context.
+ */
 function EditorCapture() {
     const [editor] = useLexicalComposerContext();
     const ctx = useContext(ToolContext);
@@ -31,6 +34,9 @@ function EditorCapture() {
     return null;
 }
 
+/**
+ * Placeholder content shown when the editor is empty.
+ */
 function Placeholder() {
     return (
         <div className="pointer-events-none absolute top-4 left-4 text-gray-400">
@@ -39,6 +45,9 @@ function Placeholder() {
     );
 }
 
+/**
+ * Rich text editor powered by Lexical and integrated with agent tools.
+ */
 export default function LexicalCanvas() {
     const initialConfig = {
         namespace: "editor",

--- a/components/speech/AudioVisualizer.tsx
+++ b/components/speech/AudioVisualizer.tsx
@@ -9,6 +9,9 @@ interface AudioVisualizerProps {
     working: boolean;
 }
 
+/**
+ * Circular visual indicator showing the assistant's current audio state.
+ */
 export default function AudioVisualizer({listening, speaking, working}: AudioVisualizerProps) {
     // Default classes for the visualizer
     const baseClasses =

--- a/components/speech/ToggleListeningButton.tsx
+++ b/components/speech/ToggleListeningButton.tsx
@@ -6,6 +6,12 @@ interface Props {
     toggleListening: () => void;
 }
 
+/**
+ * Button that toggles the microphone's listening state.
+ *
+ * A long press enables push-to-talk behaviour while a simple click toggles
+ * listening on or off.
+ */
 export default function ToggleListeningButton({listening, toggleListening}: Props) {
 
     const LONG_PRESS_MS = 600; // tap-vs-hold threshold

--- a/components/tool/ToolContext.tsx
+++ b/components/tool/ToolContext.tsx
@@ -12,6 +12,9 @@ type ToolCtx = {
 
 export const ToolContext = createContext<ToolCtx | null>(null);
 
+/**
+ * React context provider that stores references to Excalidraw and Lexical.
+ */
 export function ToolProvider({ children }: { children: ReactNode }) {
   const [excalidrawApi, setExcalidrawApi] = useState<ExcalidrawImperativeAPI | null>(null);
   const [lexicalEditor, setLexicalEditor] = useState<LexicalEditor | null>(null);

--- a/hooks/useExcalidrawTools.ts
+++ b/hooks/useExcalidrawTools.ts
@@ -13,7 +13,11 @@ const schema = z.object({
     ),
 });
 
-/* Returns Tool instances bound to the current Excalidraw API */
+/**
+ * Creates OpenAI agent tools bound to the current Excalidraw instance.
+ *
+ * The returned array contains a draw and read tool that operate on the canvas.
+ */
 export default function useExcalidrawTools() {
     const ctx = useContext(ToolContext);
     const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);

--- a/hooks/useLexicalTools.ts
+++ b/hooks/useLexicalTools.ts
@@ -14,6 +14,9 @@ const schema = z.object({
   markdown: z.string().describe("Full markdown document to place in the editor"),
 });
 
+/**
+ * Provides OpenAI agent tools bound to the current Lexical editor instance.
+ */
 export default function useLexicalTools() {
   const ctx = useContext(ToolContext);
   const editorRef = useRef<LexicalEditor | null>(null);

--- a/hooks/useRealtimeAgent.ts
+++ b/hooks/useRealtimeAgent.ts
@@ -5,6 +5,11 @@ import { RealtimeAgent, RealtimeSession } from "@openai/agents-realtime";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
+/**
+ * React hook that manages a connection to the OpenAI Realtime agent.
+ *
+ * Handles session creation, state updates and exposes a small API for the UI.
+ */
 export function useRealtimeAgent() {
     const [errored, setErrored] = useState<boolean | string>(false);
     const [listening, setListening] = useState(false);

--- a/lib/ai/getToken.test.ts
+++ b/lib/ai/getToken.test.ts
@@ -6,8 +6,8 @@ describe("getToken", () => {
         vi.restoreAllMocks();
     });
 
-    it("calls OpenAI API and returns JSON", async () => {
-        const mockResponse = {session: "test"};
+    it("calls OpenAI API and returns a session token", async () => {
+        const mockResponse = {client_secret: {value: "test"}};
         const json = vi.fn().mockResolvedValue(mockResponse);
         global.fetch = vi.fn().mockResolvedValue({json} as never);
 
@@ -22,6 +22,6 @@ describe("getToken", () => {
                 "Content-Type": "application/json",
             })
         }));
-        expect(result).toEqual(mockResponse);
+        expect(result).toEqual("test");
     });
 });

--- a/lib/ai/getToken.ts
+++ b/lib/ai/getToken.ts
@@ -1,5 +1,8 @@
 "use server"
 
+/**
+ * Fetches an ephemeral session token used to connect to OpenAI's realtime API.
+ */
 export async function getToken(): Promise<string> {
     const r = await fetch("https://api.openai.com/v1/realtime/sessions", {
         method: "POST",


### PR DESCRIPTION
## Summary
- add JSDoc comments across the project
- fix `getToken` unit test to expect the returned token

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68723fc9aaf4832a921682b689412c8e